### PR TITLE
Install go-cd server from debian repo

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,6 @@
-default['go_cd']['server_download_url'] = 'http://download.go.cd/gocd-deb/go-server-14.4.0-1356.deb'
 default['go_cd']['agent_download_url'] = 'http://download.go.cd/gocd/go-agent-14.4.0-1356.zip'
+default['go_cd']['apt_repo_uri'] = 'http://download.go.cd/gocd-deb/'
+default['go_cd']['package_version'] = '14.4.0-1356'
 default['go_cd']['user'] = 'go'
 default['go_cd']['group'] = 'go'
 default['go_cd']['server_ip'] = '127.0.0.1'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -2,12 +2,15 @@
 # Recipe:: default
 include_recipe 'go_cd::default'
 
-remote_file "#{Chef::Config[:file_cache_path]}/go-server.deb" do
-  source  node['go_cd']['server_download_url']
+apt_repository 'gocd' do
+  uri node['go_cd']['apt_repo_uri']
+  components ['/']
 end
 
-dpkg_package 'go-server' do
-  source "#{Chef::Config[:file_cache_path]}/go-server.deb"
+package 'go-server' do
+  version node['go_cd']['package_version']
+  options '--force-yes'
+  notifies :restart, 'service[go-server]'
 end
 
 service 'go-server' do


### PR DESCRIPTION
This is to fix the behaviour observed when directly downloading a debian
file and installing it via dpkg_package resource. In this situation,
dpkg does not recognize if a newer version than the one installed has
been downloaded. Also, using a debian repo means we're relying on proven
technology to manage packages and versions.