### PR TITLE
Use bintray gocd debian repo

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 default['go_cd']['agent_download_url'] = 'http://download.go.cd/gocd/go-agent-15.1.0-1863.zip'
-default['go_cd']['apt_repo_uri'] = 'http://download.go.cd/gocd-deb/'
+default['go_cd']['apt_repo_uri'] = 'http://dl.bintray.com/gocd/gocd-deb/'
 default['go_cd']['package_version'] = '15.1.0-1863'
 default['go_cd']['user'] = 'go'
 default['go_cd']['group'] = 'go'


### PR DESCRIPTION
I experience problems (connectivity, certificate validation) when using
the `download.go.cd` debian repository.

For example, I get this when I run `apt-get update` using the
`download.go.cd` repo:

```
W: Failed to fetch http://download.go.cd/gocd-deb/Packages  server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
```

The bintray gocd repo (which is the target of a 302 redirect from
download.go.cd/gocd) has more reliable connectivity and also does not
give certificate validation failures :)