### PR TITLE
Use download.go.cd as apt repo and add key

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,6 @@
 default['go_cd']['agent_download_url'] = 'http://download.go.cd/gocd/go-agent-15.1.0-1863.zip'
-default['go_cd']['apt_repo_uri'] = 'http://dl.bintray.com/gocd/gocd-deb/'
+default['go_cd']['apt_repo_uri'] = 'https://download.go.cd'
+default['go_cd']['apt_repo_key'] = 'https://download.go.cd/GOCD-GPG-KEY.asc'
 default['go_cd']['package_version'] = '15.1.0-1863'
 default['go_cd']['user'] = 'go'
 default['go_cd']['group'] = 'go'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -4,6 +4,7 @@ include_recipe 'go_cd::default'
 
 apt_repository 'gocd' do
   uri node['go_cd']['apt_repo_uri']
+  key node['go_cd']['apt_repo_key'] unless node['go_cd']['apt_repo_key'].nil?
   components ['/']
 end
 


### PR DESCRIPTION
New binaries are no longer being published to dl.bintray, and `apt-get update` recently started complaining that no public key was available. So let's switch to download.go.cd and use the key that go.cd tells us to use.
